### PR TITLE
Add Dockerfile and Compose

### DIFF
--- a/Cache/Dockerfile
+++ b/Cache/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:8.6.0
+
+# Run a command for creating the following path on container
+RUN mkdir -p /usr/cache-service
+
+# Sets the work directory of our app to be the new path
+WORKDIR /usr/cache-service
+
+# Copy all files from current directory to the new path in container
+COPY . /usr/cache-service
+
+# Run the command for installing our node dependencies
+RUN npm install
+
+# Define the command that will execute when the container start
+CMD npm start

--- a/Cache/package.json
+++ b/Cache/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cache-service",
+  "name": "web-server",
   "version": "1.0.0",
   "description": "redis-webserver",
   "main": "index.js",
@@ -7,7 +7,7 @@
     "start": "nodemon --exec babel-node index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "Casey Wylie",
+  "author": "",
   "license": "ISC",
   "dependencies": {
     "@babel/cli": "^7.6.0",
@@ -20,6 +20,7 @@
     "dotenv": "^8.1.0",
     "express": "^4.17.1",
     "express-session": "^1.16.2",
+    "extend": "^3.0.2",
     "helmet": "^3.21.0",
     "ioredis": "^4.14.1",
     "keycloak-admin": "^1.12.0",
@@ -27,20 +28,7 @@
     "multer": "^1.4.2",
     "nodemon": "^1.19.2",
     "redis": "^2.8.0",
+    "request": "^2.88.0",
     "socket.io": "^2.2.0"
-  },
-  "devDependencies": {},
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/cmwylie19/patternfly-chat.git"
-  },
-  "keywords": [
-    "cache",
-    "socket-io",
-    "node"
-  ],
-  "bugs": {
-    "url": "https://github.com/cmwylie19/patternfly-chat/issues"
-  },
-  "homepage": "https://github.com/cmwylie19/patternfly-chat#readme"
+  }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:8.6.0
+
+# Run a command for creating the following path on container
+RUN mkdir -p /usr/frontend
+
+# Sets the work directory of our app to be the new path
+WORKDIR /usr/frontend
+
+# Copy all files from current directory to the new path in container
+COPY . /usr/frontend
+
+# Delete the Cache folder from frontend container
+RUN rm -rf Cache
+
+# Run the command for installing our node dependencies
+RUN npm install
+
+# Define the command that will execute when the container start
+CMD npm start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: "2"
+services:
+  redis:
+    image: "redis"
+    ports:
+      - "6379:6379"
+  keycloak:
+    image: "jboss/keycloak"
+    ports:
+      - "8080:8080"
+    environment:
+      - KEYCLOAK_USER=admin
+      - KEYCLOAK_PASSWORD=admin
+      - DB_VENDOR=H2
+    depends_on:
+      - redis
+  cache-service:
+    build: ./Cache
+    ports:
+      - "3332:3332"
+    environment:
+      - REDIS_URL=redis://localhost
+    links:
+      - redis
+    depends_on:
+      - redis
+  frontend:
+    build: ./
+    ports:
+      - "3002:3002"
+    depends_on:
+      - cache-service


### PR DESCRIPTION
Closes #17 .

- [x]  Dockerfile for the frontend
- [x]  Dockerfile for the cache service
- [ ]  docker-compose.yml file to start the
- [x] Redis Container
- [x] keycloak server container
- [x] frontend
- [ ] redis micro-service

In order to containerize the cache service I had to update the package since some dependencies were missing. 
I recommend separating the project in two main folders `frontend` and `backend`, or `cache-service` and `app` whatever suits better!

I need help though. Seems like I cannot get the `cache service` to connect with `redis`. I tried a bunch of different configurations both on `docker-compose` and in the project itself. Can anyone help or have an ideia for this? I decided opening up the PR because I practically gave up after a few hours. The error is pretty straightforward, but I could build a configuration that makes the `cache service` "see" the `redis`.
```bash
cache-service_1  | [ioredis] Unhandled error event: Error: connect ECONNREFUSED 127.0.0.1:6379
cache-service_1  |     at Object._errnoException (util.js:1019:11)
cache-service_1  |     at _exceptionWithHostPort (util.js:1041:20)
cache-service_1  |     at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1175:14)
``` 